### PR TITLE
Add TXDbFailed

### DIFF
--- a/httpo/custom_status_codes.go
+++ b/httpo/custom_status_codes.go
@@ -1,6 +1,12 @@
 package httpo
 
 const (
+
+	// Half success
+
+	// Occurs when transaction is succeful but failed to add in DB
+	TXDbFailed = 5001
+	
 	// Access issues
 
 	// Occurs when token is expired


### PR DESCRIPTION
This status code is for when transaction on chain is successful but adding it to db(optional) fails.